### PR TITLE
Enable xdebug profiling through a GET/POST/COOKIE

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,8 @@ A Chassis extension to install and configure Xdebug on your Chassis server.
   e.g.<br />![Server mapping in PHPStorm](https://bronsons-captured.s3.amazonaws.com/phpstorm.png)<br />
 7. Enable `Start Listening for PHP Debug Connections` e.g.<br />![Listen For PHP Debug Connections](https://bronsons-captured.s3.amazonaws.com/README.md_-_nodeissue_-_VolumesSitesnodeissue_2016-11-07_17-57-45.png)<br />
 8. Set a breakpoint in PHPStorm and refresh the page you wish to debug in the browser and start debugging!
+
+## Xdebug Profiling
+If you'd like to enable Xdebug Profiling you can do so by doing either of the following:
+1. Append `?XDEBUG_PROFILE=1` to a URL you'd like to profile.
+2. Add `1` to the Xdebug Helper ![Chrome extension](https://bronsons-captured.s3.amazonaws.com/Xdebug_helper__2017-06-21_23-26-03.png).

--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ A Chassis extension to install and configure Xdebug on your Chassis server.
 If you'd like to enable Xdebug Profiling you can do so by doing either of the following:
 1. Append `?XDEBUG_PROFILE=1` to a URL you'd like to profile.
 2. Add `1` to the Xdebug Helper ![Chrome extension](https://bronsons-captured.s3.amazonaws.com/Xdebug_helper__2017-06-21_23-26-03.png).
+3. The profiling logs will be save on your Chassis VM under `/tmp`. You'll need to `vagrant ssh` then `cd /tmp` to view them.

--- a/modules/xdebug/templates/xdebug.ini.erb
+++ b/modules/xdebug/templates/xdebug.ini.erb
@@ -9,4 +9,7 @@ xdebug.remote_connect_back=1
 xdebug.var_display_max_depth = 10
 xdebug.var_display_max_children = 256
 xdebug.var_display_max_data = 1024
-xdebug.idekey=<%= @ide_name %>
+xdebug.idekey=<%= @ide_var %>
+# Enable php profiling with get param XDEBUG_PROFILE=1
+xdebug.profiler_enable_trigger=1
+xdebug.profiler_output_name=cachegrind.out.%t.%p


### PR DESCRIPTION
Fixes #24. Props to @mattheu for the poke on this option during WordCamp Europe!