### PR TITLE
Add VSCode and Firefox instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ A Chassis extension to install and configure Xdebug on your Chassis server.
 ### VS Code
 6. Go to the VS Code Extensions manager (or enter "Install Extensions" in the command palette) and install & activate the [PHP Debug](https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug) extension.
 7. Go to the Debug tab in the sidebar and click the small gear icon at the top of the left column; select "PHP" from the menu that will pop up to auto-create a `launch.json` PHP debugging configuration file in your project<br />![Selecting the "configure launch.json" button in VS Code](https://user-images.githubusercontent.com/442115/37500902-5055a80c-28a2-11e8-85f2-fe66c943ba7b.png)
-8. Add a "pathMappings" key to the "Listen for Xdebug" launch configuration to map the workspace root to the `/vagrant` directory within the virtual machine _e.g._<br />![Configuring pathMappings inside VS Code launch.json file](https://user-images.githubusercontent.com/442115/37501200-94d167cc-28a3-11e8-958d-7a36ab0e9d27.png)
-9. Click `Start Debugging` in the left column of the Debug tab _e.g._<br />![The "Start Debugging" button in VS Code](https://user-images.githubusercontent.com/442115/37501465-e7d620ba-28a4-11e8-8a2f-9857bdc04871.png)
+8. Add a "pathMappings" key to the "Listen for Xdebug" launch configuration to map the workspace root to the `/vagrant` directory within the virtual machine _e.g._<br />![Configuring "pathMappings": { "/vagrant": "${workspaceRoot}" } inside VS Code launch.json file](https://user-images.githubusercontent.com/442115/37502019-418bff06-28a7-11e8-9bc8-34129d9a93fc.png)
+9. Click `Start Debugging` in the left column of the Debug tab _e.g._<br />![The "Start Debugging" button in VS Code](https://user-images.githubusercontent.com/442115/37501949-ed1803e8-28a6-11e8-81f8-3cdaf7d6c1ce.png)
 9. Set a breakpoint in VS Code, refresh the page you with to debug in the browser, and start debugging!
 
 ## Xdebug Profiling

--- a/README.md
+++ b/README.md
@@ -7,22 +7,40 @@ A Chassis extension to install and configure Xdebug on your Chassis server.
 3. Run `vagrant provision`.
 4. By default PHPSTORM is the default IDE. This can be overridden in your any of your [`.yaml`](https://github.com/Chassis/Chassis/blob/master/config.yaml#L6-#L9) files by adding in:
 `ide: ATOM` and replacing ATOM with your IDE of choice. If you do this then please be sure to change your IDE Key in the Xdebug Helper extension mentioned below.
+5. Configure your browser and your IDE, set a breakpoint, and happy debugging!
 
-## PHPStorm Setup
+## Browser Setup
+
 ### In Chrome
-1. Install [Xdebug Helper](https://chrome.google.com/webstore/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaaoc).
+1. Install the [Xdebug Helper](https://chrome.google.com/webstore/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaaoc).
 2. Go to `Settings -> More Tools -> Extensions` in Google Chrome.
 3. Scroll down to `Xdebug helper` and click Options.
-4. Change the IDE Key to `PhpStorm` and the value to `PHPSTORM` e.g.<br />![Xdebug Helper PHPStorm](https://bronsons-captured.s3.amazonaws.com/Xdebug_helper_2016-11-07_17-50-49.png)<br />
-5. Enable Xdebug Helper. e.g.<br />![Enable Xdebug helper](https://bronsons-captured.s3.amazonaws.com/xdebug.png)<br />
+4. Select your editor in the IDE key dropdown, or select "Other" and enter a custom key if your editor is not listed _e.g._<br />![Xdebug Helper IDE Key selection menu in Chrome](https://bronsons-captured.s3.amazonaws.com/Xdebug_helper_2016-11-07_17-50-49.png)<br />
+5. Enable Xdebug Helper. _e.g._<br />![Enable Xdebug helper in Chrome](https://bronsons-captured.s3.amazonaws.com/xdebug.png)<br />
+
+### In Firefox
+1. Install the [Xdebug Helper](https://addons.mozilla.org/en-US/firefox/addon/xdebug-helper-for-firefox/).
+2. Go to `Menu > Add Ons > Extensions` in Firefox.
+3. Scroll to `Xdebug helper` and click Preferences.
+4. Select your editor in the IDE key dropdown, or select "Other" and enter a custom key if your editor is not listed _e.g._<br />![Xdebug Helper IDE Key selection menu in Firefox](https://user-images.githubusercontent.com/442115/37500502-42947588-28a0-11e8-93d2-c00475acebc3.png)<br />
+5. Enable Xdebug Helper. _e.g._<br />![Enable Xdebug helper in Firefox](https://user-images.githubusercontent.com/442115/37500578-a3d0dab2-28a0-11e8-8f56-5a512369e577.png)<br />
+
+## Editor Setup
 
 ### In PHPStorm
 6. Go to `Preferences -> Languages + Frameworks -> PHP -> Servers` and add a mapping for your website.
  - `File/Directory` should be set to chassis folder (i.e. where the `Vagrantfile` is in).
  - `Absolute path on the server` should be set to `/vagrant`.
-  e.g.<br />![Server mapping in PHPStorm](https://bronsons-captured.s3.amazonaws.com/phpstorm.png)<br />
-7. Enable `Start Listening for PHP Debug Connections` e.g.<br />![Listen For PHP Debug Connections](https://bronsons-captured.s3.amazonaws.com/README.md_-_nodeissue_-_VolumesSitesnodeissue_2016-11-07_17-57-45.png)<br />
-8. Set a breakpoint in PHPStorm and refresh the page you wish to debug in the browser and start debugging!
+  _e.g._<br />![Server mapping in PHPStorm](https://bronsons-captured.s3.amazonaws.com/phpstorm.png)<br />
+7. Enable `Start Listening for PHP Debug Connections` _e.g._<br />![Listen For PHP Debug Connections](https://bronsons-captured.s3.amazonaws.com/README.md_-_nodeissue_-_VolumesSitesnodeissue_2016-11-07_17-57-45.png)<br />
+9. Set a breakpoint in PhpStorm, refresh the page you with to debug in the browser, and start debugging!
+
+### VS Code
+6. Go to the VS Code Extensions manager (or enter "Install Extensions" in the command palette) and install & activate the [PHP Debug](https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug) extension.
+7. Go to the Debug tab in the sidebar and click the small gear icon at the top of the left column; select "PHP" from the menu that will pop up to auto-create a `launch.json` PHP debugging configuration file in your project<br />![Selecting the "configure launch.json" button in VS Code](https://user-images.githubusercontent.com/442115/37500902-5055a80c-28a2-11e8-85f2-fe66c943ba7b.png)
+8. Add a "pathMappings" key to the "Listen for Xdebug" launch configuration to map the workspace root to the `/vagrant` directory within the virtual machine _e.g._<br />![Configuring pathMappings inside VS Code launch.json file](https://user-images.githubusercontent.com/442115/37501200-94d167cc-28a3-11e8-958d-7a36ab0e9d27.png)
+9. Click `Start Debugging` in the left column of the Debug tab _e.g._<br />![The "Start Debugging" button in VS Code](https://user-images.githubusercontent.com/442115/37501465-e7d620ba-28a4-11e8-8a2f-9857bdc04871.png)
+9. Set a breakpoint in VS Code, refresh the page you with to debug in the browser, and start debugging!
 
 ## Xdebug Profiling
 If you'd like to enable Xdebug Profiling you can do so by doing either of the following:
@@ -31,4 +49,4 @@ If you'd like to enable Xdebug Profiling you can do so by doing either of the fo
 3. The profiling logs will be save on your Chassis VM under `/tmp`. You'll need to `vagrant ssh` then `cd /tmp` to view them.
 
 ## Troubleshooting
-If you're having issues with XDebug not working then there is a chance that port 9000 is being used by some other software on your computer. To work around this change the [port number](https://github.com/Chassis/Xdebug/blob/master/modules/xdebug/templates/xdebug.ini.erb#L6) to another value. e.g. `9001` and run `vagrant provision`
+If you're having issues with XDebug not working then there is a chance that port 9000 is being used by some other software on your computer. To work around this change the [port number](https://github.com/Chassis/Xdebug/blob/master/modules/xdebug/templates/xdebug.ini.erb#L6) to another value. e.g. `9001` and run `vagrant provision`.


### PR DESCRIPTION
These are very similar to the Chrome and PhpStorm instructions, but perhaps they will be helpful for context if people using other more bare-bones text editors are looking for guidance.