### PR TITLE
Enable autostart in Xdebug

### DIFF
--- a/modules/xdebug/templates/xdebug.ini.erb
+++ b/modules/xdebug/templates/xdebug.ini.erb
@@ -3,7 +3,7 @@ xdebug.remote_enable=1
 xdebug.remote_handler=dbgp
 xdebug.remote_host=<%= @ssh_ip %>
 xdebug.remote_port=9000
-xdebug.remote_autostart=0
+xdebug.remote_autostart=1
 xdebug.remote_connect_back=1
 xdebug.var_display_max_depth = 10
 xdebug.var_display_max_children = 256


### PR DESCRIPTION
This significantly reduces the complexity of getting a debugging client to talk to Xdebug. It removes the need to set a query variable, or cookie, or environment variable, or do so via a browser extension, etc.