### PR TITLE
Add config variable for xdebug port

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ A Chassis extension to install and configure Xdebug on your Chassis server.
 3. Run `vagrant provision`.
 4. By default PHPSTORM is the default IDE. This can be overridden in your any of your [`.yaml`](https://github.com/Chassis/Chassis/blob/master/config.yaml#L6-#L9) files by adding in:
 `ide: ATOM` and replacing ATOM with your IDE of choice. If you do this then please be sure to change your IDE Key in the Xdebug Helper extension mentioned below.
-5. Configure your browser and your IDE, set a breakpoint, and happy debugging!
+5. By default `9000` is the port for `xdebug.remote_port`. In some cases you may need to change this, depending on what other services are running on your machine. This can be overridden in your any of your [`.yaml`](https://github.com/Chassis/Chassis/blob/master/config.yaml#L6-#L9) files by adding in:
+`port: 9001` and replacing 9001 with your port of choice. If you do this then please be sure to change the port your IDE is listening to for DBGp connections.
+6. Configure your browser and your IDE, set a breakpoint, and happy debugging!
 
 ## Browser Setup
 

--- a/modules/xdebug/manifests/init.pp
+++ b/modules/xdebug/manifests/init.pp
@@ -4,7 +4,8 @@ class xdebug (
 	$path        = '/vagrant/extensions/xdebug',
 	$remote_host  = $config[hosts],
 	$php_version  = $config[php],
-	$ide          = $config[ide]
+	$ide          = $config[ide],
+	$port         = $config[port]
 ) {
 	$hosts = join($config[hosts],',')
 
@@ -16,6 +17,12 @@ class xdebug (
 		$ide_name = 'PHPSTORM'
 	} else {
 		$ide_name = $ide
+	}
+
+	if undef == $port {
+		$port_number = 9000
+	} else {
+		$port_number = $port
 	}
 
 	if ( ! empty( $config[disabled_extensions] ) and 'chassis/xdebug' in $config[disabled_extensions] ) {

--- a/modules/xdebug/templates/xdebug.ini.erb
+++ b/modules/xdebug/templates/xdebug.ini.erb
@@ -2,7 +2,7 @@ xdebug.default_enable=1
 xdebug.remote_enable=1
 xdebug.remote_handler=dbgp
 xdebug.remote_host=<%= @ssh_ip %>
-xdebug.remote_port=9000
+xdebug.remote_port=<%= @port_number %>
 xdebug.remote_autostart=1
 xdebug.remote_connect_back=1
 xdebug.var_display_max_depth = 10


### PR DESCRIPTION
Hi Guys,

I'm discussing xdebug at WordCamp SYD, I've been preparing some additional materials to publish after to help people get different environments set up.

One issue I have run into with chassis-xdebug is that there is no current way to set the port. If you're all-in on chassis (like I assume most HM folks are) then this is fine, however if you have multiple dev environments on your local machine it becomes more and more likely that port 9000 is already taken. In my case, PHP-FMP defaults to port 9000, from Laravel's Valet. Some Node apps I have installed in the past have also utilised 9000.

This PR provides a way to set the var, I copied the style of the ide_key variable, so it will default to 9000 if nothing is explicitly set.

The docs have been edited slightly - I haven't gone as far as to insert new screenshots (I use a dark theme so it would look a bit weird), as people would need to change their PHP Storm or VS Code settings to listen for DBGp connections on the new port. 

I believe it's reasonably fair to assume that if people are comfortable enough with xDebug to use this setting, they are likely also aware of the need to change it in their IDE. 

If `port` is too ambiguous in the config, happy to change it to `xdebug_port` or something similar :)

- add var within the template and Puppet file
- update the readme slightly

Cheers!